### PR TITLE
zipalign missing fix

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -26,6 +26,9 @@ expect {
 }
 '
 
+# `zipalign` is missing in "tools" folder in sdk_r23.0.2, copy it
+cp android-sdk-linux/build-tools/19.1.0/zipalign android-sdk-linux/tools/
+
 sudo /home/vagrant/android-sdk-linux/platform-tools/adb kill-server
 sudo /home/vagrant/android-sdk-linux/platform-tools/adb start-server
 sudo /home/vagrant/android-sdk-linux/platform-tools/adb devices


### PR DESCRIPTION
When try http://ionicframework.com/docs/guide/publishing.html publishing to google pay - find out that `zipalign` tool is missing in `ionic-box`. Fix this.

