### PR TITLE
update target to 22

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,7 +22,7 @@ npm install -g cordova
 npm install -g ionic
 expect -c '
 set timeout -1   ;
-spawn /home/vagrant/android-sdk-linux/tools/android update sdk -u --all --filter platform-tool,android-19,build-tools-19.1.0
+spawn /home/vagrant/android-sdk-linux/tools/android update sdk -u --all --filter platform-tool,android-22,build-tools-22.0.1
 expect { 
     "Do you accept the license" { exp_send "y\r" ; exp_continue }
     eof


### PR DESCRIPTION
http://stackoverflow.com/questions/28877109/cordova-android-project-doesnt-compile

ionic default 
platforms/android/project.properties's target is android-22

new api also are not compatible with old api(api 19)'s webkit symbol.