### PR TITLE
Changed node version to lts.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ ANDROID_SDK=http://dl.google.com/android/$ANDROID_SDK_FILENAME
 apt-get update
 apt-get install -y npm git openjdk-7-jdk ant expect
 npm install -g n
-n stable
+n lts
 
 curl -O $ANDROID_SDK
 tar -xzvf $ANDROID_SDK_FILENAME


### PR DESCRIPTION
Atm ionic requires node 4 not node 5 which is the stable version of nodejs atm.
I'ts prob more correct to define exact version 4.2.4 instead of lts.