### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###12/5/2015: Let us know where you want to see Ionic Box go: [Vote or Comment](https://github.com/driftyco/ionic-box/issues/54) on this [issue](https://github.com/driftyco/ionic-box/issues/54)
+### 12/5/2015: Let us know where you want to see Ionic Box go: [Vote or Comment](https://github.com/driftyco/ionic-box/issues/54) on this [issue](https://github.com/driftyco/ionic-box/issues/54)
 
 Ionic Box
 =============================


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
